### PR TITLE
feat: Allow use of different DBs based on URL

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -1,21 +1,3 @@
-function mssql() {
-  let MSSQL_DATABASE = process.env.MSSQL_DATABASE;
-  let MSSQL_HOST = process.env.MSSQL_HOST;
-  let MSSQL_PASSWORD = process.env.MSSQL_PASSWORD;
-  let MSSQL_TCP_PORT = process.env.MSSQL_TCP_PORT || '1433';
-  let MSSQL_USER = process.env.MSSQL_USER;
-
-  if (!MSSQL_DATABASE || !MSSQL_HOST || !MSSQL_PASSWORD || ! MSSQL_USER) {
-    return undefined;
-  }
-
-  MSSQL_DATABASE = encodeURIComponent(MSSQL_DATABASE);
-  MSSQL_PASSWORD = encodeURIComponent(MSSQL_PASSWORD);
-  MSSQL_USER = encodeURIComponent(MSSQL_USER);
-
-  return `mssql://${MSSQL_USER}:${MSSQL_PASSWORD}@${MSSQL_HOST}:${MSSQL_TCP_PORT}/${MSSQL_DATABASE}`;
-}
-
 module.exports = {
   host: 'localhost',
   port: 5050,
@@ -56,7 +38,7 @@ module.exports = {
       passwordField: 'password'
     }
   },
-  mssql: mssql(),
+  databaseUrl: process.env.DATABASE_URL,
   sessionSecret: 'replace with unique session secret',
   tlsEnabled: false,
 };

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -1,10 +1,9 @@
 const Sequelize = require('sequelize');
 
 module.exports.sequelize = function sequelize(app) {
-  const connectionString = app.get('mssql');
-  if (!connectionString) throw new Error('Database connection string is not set in config \'mssql\'');
+  const connectionString = app.get('databaseUrl');
+  if (!connectionString) throw new Error('Database connection string is not set in config \'databaseUrl\'');
   const sequelize = new Sequelize(connectionString, {
-    dialect: 'mssql',
     //logging: console.log,
     logging: false,
     define: {


### PR DESCRIPTION
### Summary

Use DATABASE_URL as sequelize connection string instead of MSSQL specific variables.  The Adaptable.io Feathers template should be merged before this is merged.