### PR TITLE
feat: Add a congratulations message to the login page with next steps

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -10,9 +10,95 @@ client.configure(feathers.authentication());
 
 // Login screen
 const loginHTML = `<main class="login container">
+
+  <!-- REMOVE MESSAGE BEGIN -->
+
+  <div style="background-color: rgb(4 0 255 / 6%); padding: 15px; border-radius: 10px; margin-top: 10px;">
+    <div class="row">
+      <div class="col-6 push-3 col-3-tablet no-push-tablet text-center">
+        <img src="https://adaptable.io/img/party-popper.svg" style="max-width: 200px;" />
+      </div>
+      <div class="col-12 col-6-tablet text-center">
+        <h2 class="font-900 h1">Congratulations!</h2>
+        <p style="font-size: 1.5rem">
+          Your app is now running on
+        </p>
+        <img src="https://adaptable.io/img/color lockup.svg" style="max-width: 200px;" />
+      </div>
+      <div class="none inline-tablet col-3-tablet text-center">
+        <img src="https://adaptable.io/img/party-popper.svg" style="max-width: 200px;" />
+      </div>
+    </div>
+
+    <h2 class="font-900 h1 text-center">What's Next?</h2>
+
+    <p class="text-center">
+      Here are a few ideas on what to do with your new app.
+    </p>
+
+    <div class="row flex flex-row flex-wrap">
+
+      <div class="col-12 col-6-tablet col-3-desktop">
+        <h4 class="font-900" style="margin-bottom: .8em">
+          1. Check out your new app
+        </h4>
+        <p>
+          Enter an email and password below to sign up with your real-time chat app.
+        </p>
+        <p>
+          Tip: Use an incognito browser window to sign up a second user and chat with yourself.
+        </p>
+      </div>
+
+      <div class="col-12 col-6-tablet col-3-desktop">
+        <h4 class="font-900" style="margin-bottom: .8em">
+          2. Remove this message
+        </h4>
+        <p>
+          Clone your new repo and edit the app source code to remove this message.
+          Push your changes to GitHub and Adaptable will automatically re-deploy to the cloud.
+        </p>
+      </div>
+
+      <div class="col-12 col-6-tablet col-3-desktop">
+        <h4 class="font-900" style="margin-bottom: .8em">
+          3. Enable GitHub auth
+        </h4>
+        <p>
+          Add values for the environment variables <strong>GITHUB_CLIENT_ID</strong>
+          and <strong>GITHUB_CLIENT_SECRET</strong> to your Adaptable app and
+          re-deploy to enable your app's users to log in with a GitHub account.
+        </p>
+      </div>
+
+      <div class="col-12 col-6-tablet col-3-desktop">
+        <h4 class="font-900" style="margin-bottom: .8em">
+          4. Add more Feathers API services
+        </h4>
+        <p>
+          Add more MongoDB-backed API endpoints to your app using the 
+          <a target="_blank" href="https://docs.feathersjs.com/guides/basics/services.html#generating-a-service">Feathers Generator CLI</a>.
+        </p>
+      </div>
+
+    </div>
+
+    <div class="row">
+      <p class="text-center">
+        See the <a href="https://adaptable.io/docs/starters/feathers-chat-starter#what-s-next" target="_blank">Feathers Chat Starter Guide</a> for step-by-step
+        instructions for each.
+      </p>
+      <p class="text-center">
+        <a target="_blank" href="https://adaptable.io/docs/starters/feathers-chat-starter#what-s-next" style="background: #363795; padding: 13px 30px; border-radius: 30px; color: #fff; font-size:18px;">Go to the Starter Guide</a>
+      </p>
+    </div>
+  </div>
+
+  <!-- REMOVE MESSAGE END -->
+
   <div class="row">
     <div class="col-12 col-6-tablet push-3-tablet text-center heading">
-      <h1 class="font-100">Log in or signup</h1>
+      <h1 class="font-100">Feathers Chat<br />Log in or signup</h1>
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
Adds a congrats message to the login page and tries to give them some next steps, along with pointing them toward more detailed info in the new Feathers Chat Starter guide.

Note that links will not work until the corresponding io PR is pushed to prod.

The image below shows what the new login page looks like on desktop widths. I'm not super happy with the look, but I think it's sufficient for now. I think it's important that the page:

* Clearly delineates the congrats message from the actual app
* Has some Adaptable branding for continuity in the demo app workflow
* Gives enough info to help the user understand what just happened
* Teases enough interesting value to the user to entice them to continue engaging.
* Gives them enough info that they can actually do more (with help from supporting doc)
* Make the supporting doc a clear next step

![image](https://user-images.githubusercontent.com/17746857/154177490-766b2a86-a39d-4113-ba59-dd9a10cbf803.png)
